### PR TITLE
Add GitHub Actions workflow for syncing piped-plugin-sdk-go with pipecd repository

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -17,9 +17,9 @@ jobs:
           repository: pipe-cd/pipecd
           path: pipecd
       - run: |
-          git -C pipecd rev-parse HEAD > piped-plugin-sdk-go/HEAD.txt
           cd piped-plugin-sdk-go
           rm -rf * && cp -rf ../pipecd/pkg/plugin/sdk/* .
+          git -C ../pipecd rev-parse HEAD > HEAD.txt
           cp -rf ../pipecd/pkg/plugin/sdk/README.remote.md README.md
           if [[ -z `git status --porcelain` ]]; then
             exit


### PR DESCRIPTION
We decided to manage SDK implementation in the pipe-cd/pipecd repository and sync them into this repository like the examples repository.