### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
           ---
 
           EOF
-          git log --reverse --format="%s" $LATEST_VERSION_PIPECD_COMMIT..$CURRENT_SYNCED_PIPECD_COMMIT -- ./pkg/plugin/sdk/ | sed -E 's/\(#([0-9]+)\)/([#\1](https:\/\/github.com\/pipe-cd\/pipecd\/pull\/\1))/g' >> output.tmp
+          git log --reverse --format="* %s" $LATEST_VERSION_PIPECD_COMMIT..$CURRENT_SYNCED_PIPECD_COMMIT -- ./pkg/plugin/sdk/ | sed -E 's/\(#([0-9]+)\)/([#\1](https:\/\/github.com\/pipe-cd\/pipecd\/pull\/\1))/g' >> output.tmp
 
           cd ../piped-plugin-sdk-go
           gh release create --draft --target "$(git rev-parse HEAD)" --title $INPUT_VERSION --notes-file ../pipecd/output.tmp $INPUT_VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           LATEST_VERSION_PIPECD_COMMIT="$(git show $LATEST_VERSION:./HEAD.txt)"
           CURRENT_SYNCED_PIPECD_COMMIT="$(cat ./HEAD.txt)"
           echo "Previous version PipeCD commit: $LATEST_VERSION_PIPECD_COMMIT"
-          echo "Next version PipeCD commit : $CURRENT_SYNCED_PIPECD_COMMIT"
+          echo "Next version PipeCD commit: $CURRENT_SYNCED_PIPECD_COMMIT"
 
           cd ../pipecd
           cat > output.tmp <<EOF

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,56 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: piped-plugin-sdk-go
+          fetch-depth: 0
+      - uses: actions/checkout@v5
+        with:
+          repository: pipe-cd/pipecd
+          path: pipecd
+          fetch-depth: 0
+      - env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          cd piped-plugin-sdk-go
+          LATEST_VERSION=$(git tag --sort=version:refname | tail -n 1)
+          if [[ -z "$LATEST_VERSION" ]]; then
+            LATEST_VERSION=$(git log --format="%H" --reverse -- HEAD.txt | head -n 1)
+          fi
+
+          echo "Latest version: $LATEST_VERSION"
+          echo "Input version: $INPUT_VERSION"
+          if [[ "$LATEST_VERSION" == "$INPUT_VERSION" ]]; then
+            echo "Version $INPUT_VERSION already exists"
+            exit 0
+          fi
+
+          LATEST_VERSION_PIPECD_COMMIT="$(git show $LATEST_VERSION:./HEAD.txt)"
+          CURRENT_SYNCED_PIPECD_COMMIT="$(cat ./HEAD.txt)"
+          echo "Previous version PipeCD commit: $LATEST_VERSION_PIPECD_COMMIT"
+          echo "Next version PipeCD commit : $CURRENT_SYNCED_PIPECD_COMMIT"
+
+          cd ../pipecd
+          cat > output.tmp <<EOF
+          Release $INPUT_VERSION with changes since $LATEST_VERSION
+          ---
+
+          EOF
+          git log --reverse --format="%s" $LATEST_VERSION_PIPECD_COMMIT..$CURRENT_SYNCED_PIPECD_COMMIT -- ./pkg/plugin/sdk/ | sed -E 's/\(#([0-9]+)\)/([#\1](https:\/\/github.com\/pipe-cd\/pipecd\/pull\/\1))/g' >> output.tmp
+
+          cd ../piped-plugin-sdk-go
+          gh release create --draft --target "$(git rev-parse HEAD)" --title $INPUT_VERSION --notes-file ../pipecd/output.tmp $INPUT_VERSION


### PR DESCRIPTION
SSIA

Note:
The first release note should be like this.

```markdown
Release v0.1.0 with changes since 780d79f35f4e2502d8d28973303d9ef54db8f683
---

* [SDK] Use new import paths and remove unused ([#5885](https://github.com/pipe-cd/pipecd/pull/5885))
* [SDK] Prepare to publish SDK repository ([#5894](https://github.com/pipe-cd/pipecd/pull/5894))
* add more fields from deployment proto to deployment model for scriptrun plugin ([#5902](https://github.com/pipe-cd/pipecd/pull/5902))
* Fix nil pointer dereference error on spec.plugins config on app config not set ([#5922](https://github.com/pipe-cd/pipecd/pull/5922))
* Fix the build quick sync stages method to return an empty response ([#5926](https://github.com/pipe-cd/pipecd/pull/5926))
* Add default response of DetermineStrategy() of DeploymentPlugin ([#5929](https://github.com/pipe-cd/pipecd/pull/5929))
* pass 'name' from piped to plugin ([#5931](https://github.com/pipe-cd/pipecd/pull/5931))
* User PipedPlugin.Name instead of passing --name ([#5936](https://github.com/pipe-cd/pipecd/pull/5936))
* [SDK] Allow users to set nothing config for the plugin in the app.pipecd.yaml ([#5937](https://github.com/pipe-cd/pipecd/pull/5937))
* Deprecate `ArtifactVersion.kind` ([#5939](https://github.com/pipe-cd/pipecd/pull/5939))
* Add index validation of buildPipelineSyncStages in planner ([#5946](https://github.com/pipe-cd/pipecd/pull/5946))
* Improve docs for piped-plugin-sdk-go ([#5957](https://github.com/pipe-cd/pipecd/pull/5957))
* [SDK] add unit types to use in config types ([#5959](https://github.com/pipe-cd/pipecd/pull/5959))
* Remove pipelineStage ID config from SDK logic ([#5965](https://github.com/pipe-cd/pipecd/pull/5965))
* [Stage Plugins] Add MetadataKeyStageDisplay and AuthorizedOperators to the SDK ([#6000](https://github.com/pipe-cd/pipecd/pull/6000))
* [PlanPreview Plugin] Implemented SDK-side ([#6004](https://github.com/pipe-cd/pipecd/pull/6004))
* Remove unused 'pluginName' to fix lint error ([#6007](https://github.com/pipe-cd/pipecd/pull/6007))
* [stage plugins] SDK: add MetadataKeyStageApprovedUsers and DeploymentSource.SharedConfigDirectory ([#6049](https://github.com/pipe-cd/pipecd/pull/6049))
* sdk: Impl GetApplicationSharedObject(), PutApplicationSharedObject() ([#6053](https://github.com/pipe-cd/pipecd/pull/6053))
* [SDK] Parse plugin configs only once ([#6051](https://github.com/pipe-cd/pipecd/pull/6051))
* [SDK] Add custom initialization of pluign ([#6058](https://github.com/pipe-cd/pipecd/pull/6058))
* add stageIndex and correct logPersisterTest write method ([#6074](https://github.com/pipe-cd/pipecd/pull/6074))
* Add default attributes to the pluign logger ([#6079](https://github.com/pipe-cd/pipecd/pull/6079))
* update Response ([#6095](https://github.com/pipe-cd/pipecd/pull/6095))
* add nil check and expose Found field ([#6103](https://github.com/pipe-cd/pipecd/pull/6103))
* Add Analysis Stage Plugin - Core Structure Implementation ([#6097](https://github.com/pipe-cd/pipecd/pull/6097))
* [SDK]: Update ListStageCommands to accept sdk CommandType ([#6116](https://github.com/pipe-cd/pipecd/pull/6116))
* Implement with initializer to sdk ([#6158](https://github.com/pipe-cd/pipecd/pull/6158))
* add found to GetApplicationSharedObject ([#6157](https://github.com/pipe-cd/pipecd/pull/6157))
* Fix nil pointer plugin config ([#6164](https://github.com/pipe-cd/pipecd/pull/6164))
* Remove setting defaults in the SDK ([#6168](https://github.com/pipe-cd/pipecd/pull/6168))
* add StageStatusSkipped to the SDK ([#6156](https://github.com/pipe-cd/pipecd/pull/6156))
```

changes are got by this command.
```sh
$ git log --reverse --format="* %s" 10de2b05bc7a3e58de9f3bebb7e2318043cf1e3e..bc48830efb3679b2f4a48b2af6a256e59b5a27b2 -- ./pkg/plugin/sdk/ | sed -E 's/\(#([0-9]+)\)/([#\1](https:\/\/github.com\/pipe-cd\/pipecd\/pull\/\1))/g'
```