### PR TITLE
feat: extend ExecuteStageResponse with per-target DeployTargetStatuses

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -594,9 +594,26 @@ func newDeployment(deployment *model.Deployment) Deployment {
 	}
 }
 
+// DeployTargetStatus holds the result of a single deploy target within a stage execution.
+type DeployTargetStatus struct {
+	// Name is the deploy target name, matching sdk.DeployTarget[T].Name.
+	Name string
+	// Status is the outcome for this specific target.
+	Status StageStatus
+	// Message is an optional human-readable detail (e.g. error summary).
+	Message string
+}
+
 // ExecuteStageResponse is the response of the request to execute a stage.
 type ExecuteStageResponse struct {
+	// Status is the overall stage outcome. Callers that do not populate
+	// DeployTargetStatuses must still set this field — it is the authoritative
+	// result piped acts on.
 	Status StageStatus
+	// DeployTargetStatuses reports the per-target outcome when the stage ran
+	// across multiple deploy targets. Nil means the plugin did not report
+	// per-target detail (piped treats it as absent, not as failure).
+	DeployTargetStatuses []DeployTargetStatus
 }
 
 // StageStatus represents the current status of a stage of a deployment.


### PR DESCRIPTION
**What this PR does**:
Adds a new `DeployTargetStatus` type and extends `ExecuteStageResponse` with a `DeployTargetStatuses []DeployTargetStatus` field.

```go
type DeployTargetStatus struct {
    Name    string
    Status  StageStatus
    Message string
}

type ExecuteStageResponse struct {
    Status               StageStatus           // unchanged
    DeployTargetStatuses []DeployTargetStatus  // new, nil-safe
}
```

**Why we need it**:
Plugins that deploy to multiple clusters in parallel (e.g. `kubernetes_multicluster`) can now report per-target outcomes alongside the overall stage status. Callers that don't populate the new field are unaffected, a nil slice is treated as "no per-target detail reported".

**Which issue(s) this PR fixes**:
Companion to pipe-cd/pipecd#6812 (kubernetes_multicluster plugin consuming this field).

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: Plugin authors gain an optional field to surface per-target status. Existing plugins require no changes.
- **Is this breaking change**: The existing `Status` field is unchanged.
- **How to migrate (if breaking change)**: N/A